### PR TITLE
remove extrafont package

### DIFF
--- a/inst/shinyapp/metid/ui.R
+++ b/inst/shinyapp/metid/ui.R
@@ -42,11 +42,11 @@ if (!require(tidymass)) {
   install_tidymass(from = "tidymass.org")
 }
 
-if (!require(extrafont)) {
-  install.packages("extrafont")
-  library(extrafont)
-  extrafont::loadfonts()
-}
+# if (!require(extrafont)) {
+#   install.packages("extrafont")
+#   library(extrafont)
+#   extrafont::loadfonts()
+# }
 
 ui <- dashboardPage(
   skin = "blue",


### PR DESCRIPTION
I remove the extrafont package, this is not usefull in the metid shiny package.